### PR TITLE
Bounds fixes; Python 3.5 EOL

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -11,7 +11,7 @@ on:
       - published
 
 env:
-  CIBW_SKIP: cp27-* pp27-* # skip python2.7 builds
+  CIBW_SKIP: cp27-* pp27-* cp35-* # skip python2.7 builds, python3.5 EOL
 
 jobs:
   build_wheels:

--- a/glpk/_utils.py
+++ b/glpk/_utils.py
@@ -21,7 +21,7 @@ def _convert_bounds(processed_bounds):
         elif ub in {np.inf, None}:
             # lb <= x < inf
             bounds[ii] = (GLPK.GLP_LO, lb, 0)
-        elif ub < lb:
+        elif lb < ub:
             # lb <= x <= ub
             bounds[ii] = (GLPK.GLP_DB, lb, ub)
         else:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ include_dirs = [
 
 setup(
     name='scikit-glpk',
-    version='0.3.0',
+    version='0.3.1',
     author='Nicholas McKibben',
     author_email='nicholas.bgp@gmail.com',
     url='https://github.com/mckib2/scikit-glpk',


### PR DESCRIPTION
- Stop generating cpython 3.5 wheels
- Correct bounds check on linprog bound conversion to GLPK-styl bounds

Closes issues #10 and #11.