### PR TITLE
fix get dual indexing error

### DIFF
--- a/glpk/_glpk.py
+++ b/glpk/_glpk.py
@@ -367,7 +367,7 @@ def glpk(
 
             res.fun = _lib.glp_get_obj_val(prob)
             res.x = np.array([_lib.glp_get_col_prim(prob, ii) for ii in range(1, len(c)+1)])
-            res.dual = np.array([_lib.glp_get_col_dual(prob, ii) for ii in range(1, len(b_ub)+1)])
+            res.dual = np.array([_lib.glp_get_row_dual(prob, ii) for ii in range(1, len(b_ub)+1)])
 
             # We don't get slack without doing sensitivity analysis since GLPK
             # uses auxiliary variables instead of slack!

--- a/glpk/_glpk.py
+++ b/glpk/_glpk.py
@@ -414,7 +414,7 @@ def glpk(
 
             res.fun = _lib.glp_ipt_obj_val(prob)
             res.x = np.array([_lib.glp_ipt_col_prim(prob, ii) for ii in range(1, len(c)+1)])
-            res.dual = np.array([_lib.glp_ipt_col_dual(prob, ii) for ii in range(1, len(b_ub)+1)])
+            res.dual = np.array([_lib.glp_ipt_row_dual(prob, ii) for ii in range(1, len(b_ub)+1)])
 
             # We don't get slack without doing sensitivity analysis since GLPK uses
             # auxiliary variables instead of slack!


### PR DESCRIPTION
This attempts to fix an indexing error when using the simplex method to solve LP.

I believe that this should apply to the interior point method as well.

Lastly, I think this also need to take care of the equality constraints somehow? I'm not sure if the current behavior considers that. 