### PR TITLE
Patches

### DIFF
--- a/glpk/_glpk.py
+++ b/glpk/_glpk.py
@@ -367,7 +367,7 @@ def glpk(
 
             res.fun = _lib.glp_get_obj_val(prob)
             res.x = np.array([_lib.glp_get_col_prim(prob, ii) for ii in range(1, len(c)+1)])
-            res.dual = np.array([_lib.glp_get_col_dual(prob, ii) for ii in range(1, len(b_ub)+1)])
+            res.dual = np.array([_lib.glp_get_row_dual(prob, ii) for ii in range(1, len(b_ub)+1)])
 
             # We don't get slack without doing sensitivity analysis since GLPK
             # uses auxiliary variables instead of slack!

--- a/glpk/_glpk.py
+++ b/glpk/_glpk.py
@@ -21,6 +21,7 @@ def glpk(
         bounds=None,
         solver='simplex',
         sense=GLPK.GLP_MIN,
+        scale=True,
         maxit=GLPK.INT_MAX,
         timeout=GLPK.INT_MAX,
         basis_fac='luf+ft',
@@ -278,7 +279,11 @@ def glpk(
     _lib = GLPK()._lib
 
     # Scale the problem
-    _lib.glp_scale_prob(prob, GLPK.GLP_SF_AUTO) # do auto scaling for now
+    no_need_explict_scale = (solver == "simplex" and 
+                             simplex_options.get("presolve"))
+    if not no_need_explict_scale and scale:
+        _lib.glp_scale_prob(prob, GLPK.GLP_SF_AUTO) # do auto scaling for now
+
 
     # Select basis factorization method
     bfcp = glp_bfcp()
@@ -340,7 +345,7 @@ def glpk(
         smcp.presolve = {
             True: GLPK.GLP_ON,
             False: GLPK.GLP_OFF,
-        }[simplex_options.get('presolve', GLPK.GLP_OFF)]
+        }[simplex_options.get('presolve', True)]
 
         # Simplex driver
         if simplex_options.get('exact', False):

--- a/glpk/_glpk.py
+++ b/glpk/_glpk.py
@@ -414,7 +414,7 @@ def glpk(
 
             res.fun = _lib.glp_ipt_obj_val(prob)
             res.x = np.array([_lib.glp_ipt_col_prim(prob, ii) for ii in range(1, len(c)+1)])
-            res.dual = np.array([_lib.glp_ipt_col_dual(prob, ii) for ii in range(1, len(b_ub)+1)])
+            res.dual = np.array([_lib.glp_ipt_row_dual(prob, ii) for ii in range(1, len(b_ub)+1)])
 
             # We don't get slack without doing sensitivity analysis since GLPK uses
             # auxiliary variables instead of slack!


### PR DESCRIPTION
This commit attempts to handle scaling more properly for simplex (by a bit more). 

I think GLPK automatically does scaling if it does presolve, so I avoided the explicit scaling if that's the case.

This also get rid of the message printed by `glp_scale_prob `, which I don't know how to disable otherwise.