### PR TITLE
ENH: add integrality information from MPS file

### DIFF
--- a/glpk/_fileio.py
+++ b/glpk/_fileio.py
@@ -107,6 +107,8 @@ def mpsread(filename, fmt=GLPK.GLP_MPS_FILE, ret_glp_prob=False, read_additional
         else:
             raise NotImplementedError()
 
+
+
     if ub_vals:
         # Converting to csc_matrix gets rid of all-zero rows
         A_ub = coo_matrix((ub_vals, (ub_rows, ub_cols)), shape=(max(ub_rows)+1, n))
@@ -124,6 +126,18 @@ def mpsread(filename, fmt=GLPK.GLP_MPS_FILE, ret_glp_prob=False, read_additional
         A_eq = None
         b_eq = None
 
+    # get integrality
+    integrality = [{
+        GLPK.GLP_CV: 0,
+        GLPK.GLP_IV: 1,
+        GLPK.GLP_BV: 1,
+    }[_lib.glp_get_col_kind(prob, jj)] for jj in range(1, n+1)]
+
+    # add additional constraints if binary
+    for jj in range(1, n+1):
+        if _lib.glp_get_col_kind(prob, jj) == GLPK.GLP_BV:
+            bounds[jj-1] = (0, 1)
+
     if read_additional_info:
         additional_info = {'col_names': [_lib.glp_get_col_name(prob, ii).decode('utf-8') for ii in range(1, n + 1)],
                            'row_names': [_lib.glp_get_row_name(prob, ii).decode('utf-8') for ii in range(1, m + 1)],
@@ -132,9 +146,9 @@ def mpsread(filename, fmt=GLPK.GLP_MPS_FILE, ret_glp_prob=False, read_additional
                            'prob_name': _lib.glp_get_prob_name(prob), 'obj_name': _lib.glp_get_obj_name(prob),
                            'obj_dir': _lib.glp_get_obj_dir(prob)}
 
-        return (c, A_ub, b_ub, A_eq, b_eq, bounds, additional_info)
+        return (c, A_ub, b_ub, A_eq, b_eq, bounds, integrality, additional_info)
     else:
-        return(c, A_ub, b_ub, A_eq, b_eq, bounds)
+        return(c, A_ub, b_ub, A_eq, b_eq, bounds, integrality)
 
 
 def mpswrite(

--- a/glpk/_glpk_defines.py
+++ b/glpk/_glpk_defines.py
@@ -484,6 +484,12 @@ class GLPK:
             ctypes.c_int, # jth col
         ]
 
+        _lib.glp_get_col_kind.restype = ctypes.c_int
+        _lib.glp_set_col_kind.argtypes = [
+            ctypes.POINTER(glp_prob),
+            ctypes.c_int,  # jth col
+        ]
+
         _lib.glp_set_col_kind.restype = None
         _lib.glp_set_col_kind.argtypes = [
             ctypes.POINTER(glp_prob),


### PR DESCRIPTION
- add GLPK function ctypes interface for getting column variable type information
- return `integrality` information from MPS files