### PR TITLE
FIX: correctly ignore lp from _fill_prob

### DIFF
--- a/glpk/_fileio.py
+++ b/glpk/_fileio.py
@@ -163,7 +163,7 @@ def mpswrite(
     """Write an MPS file."""
 
     filename = pathlib.Path(filename)
-    prob, _lp = _fill_prob(c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
+    prob, *_lp = _fill_prob(c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
                            integrality=integrality, binary=binary, sense=sense, prob_name=filename.stem)
 
     # Get the library
@@ -187,7 +187,7 @@ def lpwrite(c,
     """Write a CPLEX LP file."""
 
     filename = pathlib.Path(filename)
-    prob, _lp = _fill_prob(c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
+    prob, *_lp = _fill_prob(c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds,
                            integrality=integrality, binary=binary, sense=sense, prob_name=filename.stem)
 
     # Get the library


### PR DESCRIPTION
Inside functions for writing MPS and LP files the result of the function `_fill_prob` was used as
```
prob, _lp = _fill_prob(...)
```
trying to only use the `prob` parameter and ignore the rest. However, the function `_fill_prob` returns a tuple `(prob, c, A_ub, b_ub, A_eq, b_eq, processed_bounds, integrality, binary)`, causing the write functions to fail with the error
```
ValueError: too many values to unpack (expected 2)
```
which renders the writing functions defunct.

This PR solves the problem by using [extended variable unpacking](https://peps.python.org/pep-3132/).

I do not have much experience with creating pull requests, so please bear with me if I did not do everything correctly.