### PR TITLE
ENH: speed up writing sparse matrices

### DIFF
--- a/glpk/_utils.py
+++ b/glpk/_utils.py
@@ -3,7 +3,7 @@
 import ctypes
 
 import numpy as np
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_matrix, vstack
 from scipy.optimize._linprog_util import _LPProblem, _clean_inputs
 
 from ._glpk_defines import GLPK
@@ -50,8 +50,11 @@ def _fill_prob(c, A_ub, b_ub, A_eq, b_eq, bounds, integrality, binary, sense, pr
     else:
         binary = np.array(binary, dtype=bool)
 
+    # Convert to coo_matrices first so that we can concat the already sparse matrices
+    A_ub_coo = coo_matrix(A_ub)
+    A_eq_coo = coo_matrix(A_eq)
     # coo for (i, j, val) format
-    A = coo_matrix(np.concatenate((A_ub, A_eq), axis=0))
+    A = vstack((A_ub_coo, A_eq_coo))
 
     # Convert linprog-style bounds to GLPK-style bounds
     bounds = _convert_bounds(processed_bounds)


### PR DESCRIPTION
The function `_fill_prob` uses the function `np.concatenate` to stack `A_ub` and `A_eq` to a single matrix and only then it converts it to a scipy sparse matrix. As a result, only numpy matrices may be used. Specifically, sparse matrices returned by `mpsread` cannot be directly used for `mpswrite` because of this.

This PR changes this behavior to first convert both `A_ub` and `A_eq` to scipy sparse `coo_matrix` and then use the `vstack` function. This speeds up the function for sparse matrices, as it is no longer necessary to convert it to a (possibly very large) dense representation beforehand. Performance is unchanged for dense matrices, as they need to be converted to `coo_matrix` either way.

I do not have much experience with creating pull requests, so please bear with me if I did not do everything correctly.